### PR TITLE
feat(email-service): fetch data function returns event data by default

### DIFF
--- a/src/services/emailSender.ts
+++ b/src/services/emailSender.ts
@@ -232,7 +232,7 @@ class EmailSenderService extends NotificationService {
 				};
 			}
 			default: {
-				return {};
+				return eventData;
 			}
 		}
 	}


### PR DESCRIPTION
By returning default event data, we can have this option for users to have any type of event and data. Docs can be updated to convey that to is needed to provide receiver email address